### PR TITLE
Gary devel

### DIFF
--- a/config.php.template
+++ b/config.php.template
@@ -4,7 +4,7 @@
 
 */
 
-$cfgfile            = exec( "ls ~us3/lims/.us3lims.ini" );
+$cfgfile            = 'home/us3/lims/.us3lims.ini';
 $configs            = parse_ini_file( $cfgfile, true );
 $org_name           = 'UltraScan3 LIMS New Instance Setup';
 $org_site           = 'uslims.uleth.ca/uslims3_newlims';

--- a/create_instance.php
+++ b/create_instance.php
@@ -206,7 +206,7 @@ HTML;
 
 function do_step2()
 {
-  global $link;
+  global $link, $globaldbuser, $globaldbpasswd, $globaldbname, $globaldbhost;
   $metadataID = $_POST['metadataID'];
 
   setup_DB( $metadataID );
@@ -275,10 +275,10 @@ TEXT;
     <tr><th>Database user:</th><td>$new_dbuser</td></tr>
     <tr><th>DB User Password:</th><td>$new_dbpasswd</td></tr>
     <tr><th>Server name:</th><td>$new_dbhost</td></tr>
-    <tr><th>Global DB User:</th><td>gfac</td></tr>
-    <tr><th>Global DB password:</th><td>\$configs[ 'gfac' ][ 'password' ]</td></tr>
-    <tr><th>Global DB name:</th><td>gfac</td></tr>
-    <tr><th>Global DB host:</th><td>dev1-linux</td></tr>
+    <tr><th>Global DB User:</th><td>$globaldbuser</td></tr>
+    <tr><th>Global DB password:</th><td>$globaldbpasswd</td></tr>
+    <tr><th>Global DB name:</th><td>$globaldbname</td></tr>
+    <tr><th>Global DB host:</th><td>$globaldbhost</td></tr>
   </table>
 
   <p>The database instance has been created.</p>


### PR DESCRIPTION
Reduced $cfgfile to just the full path. Not sure why we need to do an exec( ls.. ) to get it.
Added global variables for gfac instead of hardcoded text in create_instance.php to show properly post creation. 