### PR TITLE
Remove webmaster, search, and partner pages

### DIFF
--- a/links.php
+++ b/links.php
@@ -81,9 +81,7 @@ HTML;
     echo <<<HTML
       <h4>General</h4>
       <a href='http://$org_site/profile.php?edit=12'>Change My Info</a>
-      <a href="partners.php">Partners</a>
       <a href="contacts.php">Contacts</a>
-      <a href="mailto:demeler@gmail.com">Webmaster</a>
       <a href='http://$org_site/logout.php'>Logout</a>
 
 HTML;
@@ -94,9 +92,7 @@ HTML;
   {
       echo <<<HTML
       <a href="request_new_instance.php">Request Instance</a>
-      <a href="partners.php">Partners</a>
       <a href="contacts.php">Contacts</a>
-      <a href="mailto:demeler@gmail.com">Webmaster</a>
       <a href='https://$org_site/login.php'>Login</a>
 
 HTML;

--- a/partners.php
+++ b/partners.php
@@ -1,1 +1,0 @@
-../partners.php

--- a/search.php
+++ b/search.php
@@ -1,1 +1,0 @@
-../search.php


### PR DESCRIPTION
This pull request primarily removes references to the `partners.php` page and the webmaster contact link from the navigation menus, and deletes unused files to clean up the codebase.

Navigation cleanup:

* Removed the `Partners` link and the `Webmaster` email link from the navigation menus in `links.php`, streamlining the user interface. [[1]](diffhunk://#diff-261982edfa6ef562383392e5ef988b21fc75aba0885a54dee9013b6171b5d9dbL84-L86) [[2]](diffhunk://#diff-261982edfa6ef562383392e5ef988b21fc75aba0885a54dee9013b6171b5d9dbL97-L99)

Codebase cleanup:

* Deleted  `partners.php` file.
* Deleted  `search.php` file.

Search was based on google api that has been deactivated.