### PR TITLE
Enable account feature

### DIFF
--- a/activate.php
+++ b/activate.php
@@ -23,13 +23,13 @@ settype( $userid, 'int' );       // Removes any remaining characters in URL
 $code   = $_GET['code'];
 
 $query = "UPDATE people SET activated = 1 " .
-         "WHERE personID=$userid AND password='$code'";
+         "WHERE personID=$userid AND password='$code' AND activated = 0 AND account_enabled = 1";
 mysqli_query($link,$query) 
       or die ("Query failed : $query<br/>" . mysqli_error($link));
 
 $query = "SELECT count(*) FROM people " .
          "WHERE personID='$userid' "    .
-         "AND password='$code' AND activated = 1";
+         "AND password='$code' AND activated = 1 AND account_enabled = 1";
 $result = mysqli_query( $link, $query ) 
           or die ( "Query failed : $query<br />" . mysqli_error($link) );
 list( $doublecheck ) = mysqli_fetch_row( $result );

--- a/checkuser.php
+++ b/checkuser.php
@@ -106,6 +106,15 @@ if ( $row["activated"] != 1 )
   exit();
 }
 
+if ( $row["account_enabled"] != 1 )
+{
+  remove_session();
+  $message = "Error: This account has been disabled. " .
+             "Please contact the administrator.";
+  include 'login.php';
+  exit();
+}
+
 // Update last login time
 
 $query = "UPDATE people SET lastLogin=now() WHERE personID=$personID";


### PR DESCRIPTION
This pull request introduces additional checks to ensure that only enabled accounts can be activated or logged into. The main focus is on improving account security by preventing actions on disabled accounts.

**Account activation and login security improvements:**

* Updated the activation logic in `activate.php` to ensure that only accounts which are enabled (`account_enabled = 1`) and not already activated can be activated. The verification query now also checks for enabled accounts.
* Added a check in `checkuser.php` to prevent disabled accounts from logging in. If an account is disabled, the session is removed and an error message is shown to the user.

**Testing**
https://aucsolutions.atlassian.net/browse/UTM-146