### PR TITLE
Fix new account registration failing on missing userNamePAM column

### DIFF
--- a/register.php
+++ b/register.php
@@ -67,7 +67,6 @@ $query = "INSERT INTO people " .
          "password        = '$db_password', " .
          "userlevel       = 0, " .
          "activated       = 0, " .
-         "userNamePAM     = '$email', " .
          "signup          = now() ";
 $result = mysqli_query( $link, $query ) 
           or die( "Query failed : $query<br/>" . mysqli_error($link) );


### PR DESCRIPTION
Fixes ehb54/ultrascan-tickets#1025

## Problem

`register.php` inserted `userNamePAM` into the new-instance request database's `people` table, which has no such column. Every new account registration died with:

```
Query failed : INSERT INTO people SET ... Unknown column 'userNamePAM' in 'field list'
```

## Change

Drops the single offending line from the INSERT. No schema change.

## Why this is safe

`userNamePAM` is still required in the per-instance `uslims3_*` LIMS databases, and this PR does not touch that. `create_instance.php` continues to set it there at all five sites (lines 349, 495, 529, 563, 597), using the user's email address as the PAM name, over a separate connection (`$link2`).

Nothing reads `userNamePAM` back out of the request database. The only `SELECT ... FROM people` in `create_instance.php` (line 461, inside `add_admins()`) also runs against `$link2` and selects `email` only.

## Verification

- `php -l` clean (PHP 7.2.24)
- Confirmed against the live request database schema: `people` has no `userNamePAM` column
- Grepped the repository: `userNamePAM` appears only in `register.php` (request DB, removed here) and `create_instance.php` (LIMS DBs, unchanged)
